### PR TITLE
[chore] small package.json cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mocha-mix",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "An easy way to test and mock your React Components",
   "main": "./index.js",
   "scripts": {
-    "test": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha --require ./mocha-processor.js test examples/tests",
-    "mocha": "node_modules/.bin/mocha --require ./mocha-processor.js test",
-    "examples": "node_modules/.bin/mocha --require ./mocha-processor.js examples/tests"
+    "test": "istanbul cover _mocha --require ./mocha-processor.js test examples/tests",
+    "mocha": "mocha --require ./mocha-processor.js test",
+    "examples": "mocha --require ./mocha-processor.js examples/tests"
   },
   "author": {
     "name": "RexK",
@@ -28,24 +28,24 @@
     "url": "https://github.com/rexk/mocha-mix"
   },
   "peerDependencies": {
-    "babel-core": "^5.x",
-    "jsdom": "^3.1.x",
-    "mockery": "*",
+    "babel-core": "^5.0",
+    "jsdom": "^3.1",
+    "mockery": "^1.4",
     "react": "*",
+    "react-router": "*",
     "react-tools": "*",
-    "sinon": "*",
-    "react-router": "*"
+    "sinon": "^1.15"
   },
   "devDependencies": {
-    "babel-core": "5.6.x",
-    "expect": "^1.6.0",
+    "babel-core": "^5.6",
+    "expect": "^1.6",
     "istanbul": "^0.3.17",
-    "jsdom": "3.1.2",
+    "jsdom": "^3.1.2",
     "mocha": "^2.2.5",
-    "mockery": "1.4.0",
-    "react": "0.13.3",
-    "react-router": "0.13.3",
-    "react-tools": "0.13.3",
-    "sinon": "1.15.x"
+    "mockery": "^1.4",
+    "react": "^0.13.3",
+    "react-router": "^0.13.3",
+    "react-tools": "^0.13.3",
+    "sinon": "^1.15"
   }
 }


### PR DESCRIPTION
:fire: remove unnecessary pathing in `scripts`.
scripts run with `npm run $script` have `node_modules/.bin` auto added to path.

also `semver`-ed deps. Some of the deps made no sense, so simplified to semvered version (see http://semver.npmjs.com/)

normally I would also :fire: all the `"*"` deps (and you really should, since you are only testing this module using semvered version of react (etc...)), but that would be a breaking change since it could potentially cause two instances of `react` to be required.

You should remove all `*` deps starting with a/the `0.2.0` release.