### PR TITLE
Updating event simulation to support passing event data

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -140,13 +140,15 @@ function stubComponent(tag, children, showDataProps) {
  * @method simulateEvent
  * @param {ReactElement or DOMNode} element that will trigger the event
  * @param {String} event that will be triggered
+ * @param {Object} data to pass with the event
  *
  * * Yahoo's implementation
  * @see https://github.com/yahoo/jsx-test/blob/master/lib/helper.js
  **/
-function simulateEvent(element, event) {
+function simulateEvent(element, event, data) {
   TestUtils.Simulate[event](
-    React.findDOMNode(element) || element
+    React.findDOMNode(element) || element,
+    data
   );
 }
 
@@ -156,13 +158,15 @@ function simulateEvent(element, event) {
  * @method simulateNativeEvent
  * @param {ReactElement or DOMNode} element that will trigger the event
  * @param {String} event that will be triggered
+ * @param {Object} nativeData to pass with the event
  *
  * * Yahoo's implementation
  * @see https://github.com/yahoo/jsx-test/blob/master/lib/helper.js
  **/
-function simulateNativeEvent(element, event) {
+function simulateNativeEvent(element, event, nativeData) {
   TestUtils.SimulateNative[event](
-    React.findDOMNode(element) || element
+    React.findDOMNode(element) || element,
+    nativeData
   );
 }
 


### PR DESCRIPTION
TestUtils supports passing event data for simulated events, which helps when testing code that operates on that data. This change adds supports for the additional argument in `simulateEvent` and `simulateNativeEvent`